### PR TITLE
Modified URL checking to allow for more regions

### DIFF
--- a/middleware_s3.py
+++ b/middleware_s3.py
@@ -109,7 +109,8 @@ def s3_auth_headers(url):
 def process_request_options(options):
     """Make changes to options dict and return it.
        This is the fuction that munki calls."""
-    if 's3.amazonaws.com' in options['url']:
+    URL_WITH_REGION = 's3-' + REGION + '.amazonaws.com'
+    if ('s3.amazonaws.com' in options['url']) or (URL_WITH_REGION in options['url']):
         headers = s3_auth_headers(options['url'])
         options['additional_headers'].update(headers)
     return options


### PR DESCRIPTION
Added a small modification to allow additional S3 URLs if the region of the bucket is not us-east. This is in relation to Issue #1 - https://github.com/waderobson/s3-auth/issues/1
