### PR TITLE
Add version string

### DIFF
--- a/middleware_s3.py
+++ b/middleware_s3.py
@@ -19,7 +19,7 @@ from Foundation import CFPreferencesCopyAppValue
 # pylint: enable=E0611
 
 BUNDLE_ID = 'com.github.waderobson.s3-auth'
-
+__version__ = '1.0'
 METHOD = 'GET'
 SERVICE = 's3'
 


### PR DESCRIPTION
Adding a __version__ string will allow the various reporting tools that hook in with Munki to collect installed versions accurately without having to rely on package strings. See https://github.com/munkireport/munkireport-php/pull/737 for the MR-PHP implementation - essentially, import the middleware module and do `middleware_s3.__version__` to return the string.