### PR TITLE
Use Python 3/Python 2, depending on what Munki's using

### DIFF
--- a/middleware_s3.py
+++ b/middleware_s3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/munki/python
 """
 Generate AWS4 authentication headers for your protected files
 

--- a/middleware_s3.py
+++ b/middleware_s3.py
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/bin/env python
 """
 Generate AWS4 authentication headers for your protected files
 


### PR DESCRIPTION
The code has already been updated to be Python 3 compatible, and both Munki 4 and Munki 5 use Python 3. This PR just changes the script to use Munki's embedded Python (3) instead of the macOS system Python (2).